### PR TITLE
Update how errors are added for Rails 6

### DIFF
--- a/lib/vindicate/vin_validator.rb
+++ b/lib/vindicate/vin_validator.rb
@@ -4,22 +4,22 @@ class VinValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
     unless value.respond_to?(:length)
-      record.errors[attribute] << 'is invalid'
-      return 
+      record.errors.add(attribute, :invalid, message: 'is invalid')
+      return
     end
     if value.length < 17
-      record.errors[attribute] << 'is too short'
+      record.errors.add(attribute, :invalid, message: 'is too short')
       return
     end
     if value.length > 17
-      record.errors[attribute] << 'is too long'
+      record.errors.add(attribute, :invalid, message: 'is too long')
       return
     end
     unless value =~ VALID_CHARS
-      record.errors[attribute] << 'contains invalid characters'
+      record.errors.add(attribute, :invalid, message: 'contains invalid characters')
       return
     end
-    record.errors[attribute] << 'is invalid' unless valid?(value)
+    record.errors.add(attribute, :invalid, message: 'is invalid') unless valid?(value)
   end
 
   private

--- a/spec/vin_validator_spec.rb
+++ b/spec/vin_validator_spec.rb
@@ -1,16 +1,13 @@
 require 'spec_helper'
 
 describe VinValidator, type: :model do
-
-  let(:klass) do
-    Class.new do
-      include ActiveModel::Validations
-      attr_accessor :number, :model
-      validates :number, vin: true
-    end
+  Klass = Class.new do
+    include ActiveModel::Validations
+    attr_accessor :number, :model
+    validates :number, vin: true
   end
 
-  subject { klass.new }
+  subject { Klass.new }
 
   context 'when VIN number is valid' do
     it { should allow_value('1GT424C80BF201935').for(:number) }


### PR DESCRIPTION
https://github.com/rails/rails/commit/abee0343686b476139c476952b1c68f1fba6b3d0
https://github.com/rails/rails/blame/80a23227ea3bbf080c51f91efd8a0512ed038821/activemodel/lib/active_model/errors.rb#L654
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.


This caused some other errors related only to the tests
```
     Failure/Error: record.errors.add(attribute, :invalid, message: 'is invalid')

     ArgumentError:
       Class name cannot be blank. You need to supply a name argument when anonymous class given
```
so also changed the tests to have a non-anonymous class.